### PR TITLE
Config: Change default port

### DIFF
--- a/config-example.js
+++ b/config-example.js
@@ -5,7 +5,7 @@
 'use strict';
 
 // Port - The port the log-viewer server will run on.
-exports.port = 8080;
+exports.port = 8000;
 
 // serverDir - the base directory for the server, this should point
 // from the location of server.js to the PS server's base directory


### PR DESCRIPTION
If I recall correctly only C9 runs on port 8080, 8081, or 8082 that being said generally PS defaults the ports to 8000 like Pokémon Showdown does